### PR TITLE
Improve documentation of withBind, plus a couple tweaks

### DIFF
--- a/Database/SQLite/Simple.hs
+++ b/Database/SQLite/Simple.hs
@@ -318,7 +318,7 @@ convertRow rowRes ncols = do
     Ok (val,col) | col == ncols -> return val
                  | otherwise -> do
                      let vals = map (\f -> (gettypename f, f)) rowRes
-                     throw (ConversionFailed
+                     throwIO (ConversionFailed
                        (show ncols ++ " values: " ++ show vals)
                        (show col ++ " slots in target type")
                        "mismatch between number of columns to \


### PR DESCRIPTION
This adds documentation to withBind explaining the rationale behind resetting the statement after use, instead of before.  Namely, it avoids a pitfall involving implicit transactions.

The other commits are minor tweaks you may or may not want:
- a60998b: Use `finally` instead of `bracket` in `withBind`.  This means the `bind` step is no longer under an async exception mask.  `bind` is not "acquiring" the same resource that `reset` is relinquishing, as `reset` does not reset bound parameters.
- f2e9f59: In `convertRow`, use `throwIO` in the first case, like the other cases do.
- Don't use named imports for `Control.Exception`.
