### PR TITLE
Make bindNamed publicly accessible

### DIFF
--- a/Database/SQLite/Simple.hs
+++ b/Database/SQLite/Simple.hs
@@ -82,6 +82,7 @@ module Database.SQLite.Simple (
   , closeStatement
   , withStatement
   , bind
+  , bindNamed
   , reset
   , columnName
   , withBind


### PR DESCRIPTION
I wrote a few little functions to mash this library up with the Pipes library, to provide streaming queries through its API, and I found that I needed the `bindNamed` function to implement some things, such as:

```
queryNamedP :: (MonadSafe m, FromRow a) => Connection -> Query -> [NamedParam] -> Producer a m ()
queryNamedP conn q ns = bracketIO open' closeStatement each'
    where open' = do s <- openStatement conn q
                     bindNamed s ns
                     return s
```
