### PR TITLE
Re-exports SQLError and other error internals

### DIFF
--- a/Database/SQLite/Simple.hs
+++ b/Database/SQLite/Simple.hs
@@ -88,8 +88,10 @@ module Database.SQLite.Simple (
   , withBind
   , nextRow
     -- ** Exceptions
-  , FormatError(fmtMessage, fmtQuery, fmtParams)
-  , ResultError(errSQLType, errHaskellType, errMessage)
+  , FormatError(..)
+  , ResultError(..)
+  , Base.SQLError(..)
+  , Base.Error(..)
   ) where
 
 import           Control.Applicative


### PR DESCRIPTION
Previously, the constructors for `FormatError` and `ResultError` weren't exported. It is useful to have them exported though - I can construct values in tests, and write prisms for the error types.

In a similar vein, SQLError from direct-sqlite pops up when using this library, and it would good to have it re-exported as a convenience.