### PR TITLE
Convert NULLs to NaN for Double/Floats

### DIFF
--- a/Database/SQLite/Simple/FromField.hs
+++ b/Database/SQLite/Simple/FromField.hs
@@ -145,10 +145,12 @@ instance FromField Word where
 
 instance FromField Double where
     fromField (Field (SQLFloat flt) _) = Ok flt
+    fromField (Field  SQLNull       _) = Ok (0/0)
     fromField f                        = returnError ConversionFailed f "expecting an SQLFloat column type"
 
 instance FromField Float where
     fromField (Field (SQLFloat flt) _) = Ok . double2Float $ flt
+    fromField (Field  SQLNull       _) = Ok (0/0)
     fromField f                        = returnError ConversionFailed f "expecting an SQLFloat column type"
 
 instance FromField Bool where

--- a/test/ParamConv.hs
+++ b/test/ParamConv.hs
@@ -37,6 +37,11 @@ testParamConvNull TestEnv{..} = TestCase $ do
   execute conn "INSERT INTO nulltype (id, t1) VALUES (?,?)" (two, "foo" :: String)
   [mr2] <- query_ conn "SELECT t1 FROM nulltype WHERE id = 2" :: IO [Only (Maybe String)]
   assertEqual "nulls" (Just "foo") (fromOnly mr2)
+  -- Test null conversion for Float/Double
+  [Only nanD] <- query_ conn "SELECT NULL" :: IO [Only Double]
+  assertBool "NULL for Double" $ isNaN nanD
+  [Only nanF] <- query_ conn "SELECT NULL" :: IO [Only Float]
+  assertBool "NULL for Float" $ isNaN nanF
 
 testParamConvInt :: TestEnv -> Test
 testParamConvInt TestEnv{..} = TestCase $ do


### PR DESCRIPTION
SQLite stores NaN as NULL so we convert them back as NaN. Small program to illustrate issue. 

``` haskell
go = withConnection ":memory:" $ \h -> do
  execute_ h "CREATE TABLE foo (x REAL)"
  execute h "INSERT INTO foo VALUES (?)" (Only (1::Double))
  execute h "INSERT INTO foo VALUES (?)" (Only ((0/0)::Double))
  mapM_ print =<< (query_ h "SELECT * FROM foo" :: IO [Only (Maybe Double)])
  mapM_ print =<< (query_ h "SELECT * FROM foo" :: IO [Only Double])
```

Output

```
*Main> go
Only {fromOnly = Just 1.0}
Only {fromOnly = Nothing}
*** Exception: ConversionFailed {errSQLType = "NULL", errHaskellType = "Double", errMessage = "expecting an SQLFloat column type"}
```

SQLite using same representation for NaN and NULL could cause some troubles. It makes impossible to distinguish between `Just NaN` and `Nothing`. So I'm not sure it is right thing to do.
