### PR TITLE
Added executeMany.

### DIFF
--- a/Database/SQLite/Simple.hs
+++ b/Database/SQLite/Simple.hs
@@ -313,10 +313,10 @@ execute conn template qs =
 --
 -- Throws 'FormatError' if the query could not be formatted correctly.
 executeMany :: ToRow q => Connection -> Query -> [q] -> IO ()
-executeMany conn template rows = withStatement conn template $ \stmt -> do
+executeMany conn template paramRows = withStatement conn template $ \stmt -> do
   let Statement stmt' = stmt
-  forM_ rows $ \row ->
-    withBind stmt row
+  forM_ paramRows $ \params ->
+    withBind stmt params
       (void . Base.step $ stmt')
 
 

--- a/Database/SQLite/Simple.hs
+++ b/Database/SQLite/Simple.hs
@@ -314,10 +314,10 @@ execute conn template qs =
 -- Throws 'FormatError' if the query could not be formatted correctly.
 executeMany :: ToRow q => Connection -> Query -> [q] -> IO ()
 executeMany conn template rows = withStatement conn template $ \stmt -> do
-    let Statement stmt' = stmt
-    forM_ rows $ \row ->
-        withBind stmt row
-            (void . Base.step $ stmt')
+  let Statement stmt' = stmt
+  forM_ rows $ \row ->
+    withBind stmt row
+      (void . Base.step $ stmt')
 
 
 doFoldToList :: RowParser row -> Statement -> IO [row]

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -5,17 +5,17 @@ import Control.Monad     (when)
 import System.Exit       (exitFailure)
 import System.IO
 
-import Simple
-import ParamConv
-import Errors
-import Utf8Strings
-import UserInstances
-import TestImports()
-import Fold
-import Statement
 import Debug
 import DirectSqlite
+import Errors
+import Fold
+import ParamConv
+import Simple
+import Statement
+import TestImports()
 import TestImports
+import UserInstances
+import Utf8Strings
 
 tests :: [TestEnv -> Test]
 tests =
@@ -25,6 +25,7 @@ tests =
     , TestLabel "Simple"    . testSimpleTime
     , TestLabel "Simple"    . testSimpleTimeFract
     , TestLabel "Simple"    . testSimpleInsertId
+    , TestLabel "Simple"    . testSimpleMultiInsert
     , TestLabel "Simple"    . testSimpleUTCTime
     , TestLabel "Simple"    . testSimpleUTCTimeTZ
     , TestLabel "Simple"    . testSimpleUTCTimeParams

--- a/test/Simple.hs
+++ b/test/Simple.hs
@@ -7,6 +7,7 @@ module Simple (
   , testSimpleTime
   , testSimpleTimeFract
   , testSimpleInsertId
+  , testSimpleMultiInsert
   , testSimpleUTCTime
   , testSimpleUTCTimeTZ
   , testSimpleUTCTimeParams
@@ -139,6 +140,16 @@ testSimpleInsertId TestEnv{..} = TestCase $ do
   (Only "test string") @=? (head rows)
   [Only row] <- query conn "SELECT t FROM test_row_id WHERE id = ?" (Only (2 :: Int)) :: IO [Only String]
   "test2" @=? row
+
+testSimpleMultiInsert :: TestEnv -> Test
+testSimpleMultiInsert TestEnv{..} = TestCase $ do
+  execute_ conn "CREATE TABLE test_multi_insert (id INTEGER PRIMARY KEY, t1 TEXT, t2 TEXT)"
+  executeMany conn "INSERT INTO test_multi_insert (t1, t2) VALUES (?, ?)" ([("foo", "bar"), ("baz", "bat")] :: [(String, String)])
+  id2 <- lastInsertRowId conn
+  2 @=? id2
+
+  rows <- query_ conn "SELECT id,t1,t2 FROM test_multi_insert" :: IO [(Int, String, String)]
+  [(1, "foo", "bar"), (2, "baz", "bat")] @=? rows
 
 testSimpleUTCTime :: TestEnv -> Test
 testSimpleUTCTime TestEnv{..} = TestCase $ do


### PR DESCRIPTION
This PR adds `executeMany`, based on a similar function in [postgresql-simple](https://hackage.haskell.org/package/postgresql-simple-0.5.2.1/docs/Database-PostgreSQL-Simple.html#v:executeMany). The main use case for this is inserting multiple rows, although it can be used to repeatedly execute any query with different parameters.