### PR TITLE
Add instance Semigroup Query

### DIFF
--- a/Database/SQLite/Simple/Types.hs
+++ b/Database/SQLite/Simple/Types.hs
@@ -25,6 +25,7 @@ module Database.SQLite.Simple.Types
 
 import           Control.Arrow (first)
 import           Data.Monoid (Monoid(..))
+import           Data.Semigroup (Semigroup(..))
 import           Data.String (IsString(..))
 import           Data.Tuple.Only (Only(..))
 import           Data.Typeable (Typeable)
@@ -69,9 +70,13 @@ instance Read Query where
 instance IsString Query where
     fromString = Query . T.pack
 
+instance Semigroup Query where
+    Query a <> Query b = Query (T.append a b)
+    {-# INLINE (<>) #-}
+
 instance Monoid Query where
     mempty = Query T.empty
-    mappend (Query a) (Query b) = Query (T.append a b)
+    mappend = (<>)
     {-# INLINE mappend #-}
 
 -- | A composite type to parse your custom data structures without

--- a/sqlite-simple.cabal
+++ b/sqlite-simple.cabal
@@ -49,6 +49,7 @@ Library
     bytestring >= 0.9,
     containers,
     direct-sqlite >= 2.3.13 && < 2.4,
+    semigroups == 0.18.*,
     text >= 0.11,
     time,
     transformers,


### PR DESCRIPTION
This let's the package build on GHC 8.4.1
This also adds the `semigroups` package as a dependency, which provides
backwards compatibility to earlier GHC versions.