### PR TITLE
Added FromField Instance for SQLData

### DIFF
--- a/Database/SQLite/Simple/FromField.hs
+++ b/Database/SQLite/Simple/FromField.hs
@@ -196,7 +196,7 @@ instance FromField Day where
   fromField f = returnError ConversionFailed f "expecting SQLText column type"
 
 instance FromField SQLData where
-  fromField (Field ft _)     = Ok ft
+  fromField f = Ok (fieldData f)
 
 fieldTypename :: Field -> String
 fieldTypename = B.unpack . gettypename . result

--- a/Database/SQLite/Simple/FromField.hs
+++ b/Database/SQLite/Simple/FromField.hs
@@ -100,7 +100,7 @@ class FromField a where
 
 instance (FromField a) => FromField (Maybe a) where
     fromField (Field SQLNull _) = pure Nothing
-    fromField f                 = Just <$> fromField f
+    fromField f                 = Just <$> fromField f                           
 
 instance FromField Null where
     fromField (Field SQLNull _) = pure Null
@@ -194,6 +194,9 @@ instance FromField Day where
       Left e -> returnError ConversionFailed f ("couldn't parse Day field: " ++ e)
 
   fromField f = returnError ConversionFailed f "expecting SQLText column type"
+
+instance FromField SQLData where
+  fromField (Field ft _)     = Ok ft
 
 fieldTypename :: Field -> String
 fieldTypename = B.unpack . gettypename . result

--- a/Database/SQLite/Simple/FromField.hs
+++ b/Database/SQLite/Simple/FromField.hs
@@ -100,7 +100,7 @@ class FromField a where
 
 instance (FromField a) => FromField (Maybe a) where
     fromField (Field SQLNull _) = pure Nothing
-    fromField f                 = Just <$> fromField f                           
+    fromField f                 = Just <$> fromField f
 
 instance FromField Null where
     fromField (Field SQLNull _) = pure Null

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -54,6 +54,7 @@ tests =
     , TestLabel "Utf8"      . testUtf8Simplest
     , TestLabel "Utf8"      . testBlobs
     , TestLabel "Instances" . testUserFromField
+    , TestLabel "Instances" . testSQLDataFromField
     , TestLabel "Fold"      . testFolds
     , TestLabel "Statement" . testBind
     , TestLabel "Statement" . testDoubleBind


### PR DESCRIPTION
In a recent project, I used the sqlite-simple library to do data dumps of all the tables in a database. Since I did not know how many tables were in the database or what their schemas would be, I created my own data type with its own FromField instance to be able to dynamically read all possible field values (i.e. all the possible type constructors of SQLData). Since the type constructors of my data type and SQLData were identical, I decided to add a FromField instance for SQLData.

Having this instance would be very useful when reading from multiple tables with different schemas or when you simply do not know a table's schema. 