### PR TITLE
Dataype generic implementation of {From,To}Row

### DIFF
--- a/Database/SQLite/Simple/ToRow.hs
+++ b/Database/SQLite/Simple/ToRow.hs
@@ -1,3 +1,5 @@
+{-# Language DefaultSignatures, FlexibleContexts, DeriveAnyClass,
+  StandaloneDeriving #-}
 ------------------------------------------------------------------------------
 -- |
 -- Module:      Database.SQLite.Simple.ToRow
@@ -17,52 +19,58 @@
 ------------------------------------------------------------------------------
 
 module Database.SQLite.Simple.ToRow
-    (
-      ToRow(..)
+    ( GToRow(..)
+    , ToRow(..)
     ) where
+
+import GHC.Generics
 
 import Database.SQLite.Simple.ToField (ToField(..))
 import Database.SQLite.Simple.Types (Only(..), (:.)(..))
 
 import Database.SQLite3 (SQLData(..))
 
+-- | Generic derivation of 'ToRow'.  For details about what can be
+-- derived refer to 'Database.Sqlite.Simple.FromRow.GFromRow'.
+--
+-- @since 0.4.18.1
+class GToRow f where
+  gtoRow :: (f a) -> [SQLData]
+
+instance GToRow U1 where
+  gtoRow U1 = mempty
+
+instance ToField a => GToRow (K1 i a) where
+  gtoRow (K1 a) = pure $ toField a
+
+instance (GToRow a, GToRow b) => GToRow (a :*: b) where
+  gtoRow (a :*: b) = gtoRow a `mappend` gtoRow b
+
+instance GToRow a => GToRow (M1 i c a) where
+  gtoRow (M1 a) = gtoRow a
+
 -- | A collection type that can be turned into a list of 'SQLData'
 -- elements.
+--
+-- Since version 0.4.18.1 it is possible in some cases to derive a
+-- generic implementation for 'ToRow'.  Refer to the documentation for
+-- 'Database.Sqlite.Simple.FromRow.FromRow' to see how this can be
+-- done.
 class ToRow a where
     toRow :: a -> [SQLData]
     -- ^ 'ToField' a collection of values.
 
-instance ToRow () where
-    toRow _ = []
+    default toRow :: Generic a => GToRow (Rep a) => a -> [SQLData]
+    toRow a = gtoRow $ from a
 
-instance (ToField a) => ToRow (Only a) where
-    toRow (Only v) = [toField v]
-
-instance (ToField a, ToField b) => ToRow (a,b) where
-    toRow (a,b) = [toField a, toField b]
-
-instance (ToField a, ToField b, ToField c) => ToRow (a,b,c) where
-    toRow (a,b,c) = [toField a, toField b, toField c]
-
-instance (ToField a, ToField b, ToField c, ToField d) => ToRow (a,b,c,d) where
-    toRow (a,b,c,d) = [toField a, toField b, toField c, toField d]
-
-instance (ToField a, ToField b, ToField c, ToField d, ToField e)
-    => ToRow (a,b,c,d,e) where
-    toRow (a,b,c,d,e) =
-        [toField a, toField b, toField c, toField d, toField e]
-
-instance (ToField a, ToField b, ToField c, ToField d, ToField e, ToField f)
-    => ToRow (a,b,c,d,e,f) where
-    toRow (a,b,c,d,e,f) =
-        [toField a, toField b, toField c, toField d, toField e, toField f]
-
-instance (ToField a, ToField b, ToField c, ToField d, ToField e, ToField f,
-          ToField g)
-    => ToRow (a,b,c,d,e,f,g) where
-    toRow (a,b,c,d,e,f,g) =
-        [toField a, toField b, toField c, toField d, toField e, toField f,
-         toField g]
+deriving instance ToRow ()
+deriving instance (ToField a) => ToRow (Only a)
+deriving instance (ToField a, ToField b) => ToRow (a,b)
+deriving instance (ToField a, ToField b, ToField c) => ToRow (a,b,c)
+deriving instance (ToField a, ToField b, ToField c, ToField d) => ToRow (a,b,c,d)
+deriving instance (ToField a, ToField b, ToField c, ToField d, ToField e) => ToRow (a,b,c,d,e)
+deriving instance (ToField a, ToField b, ToField c, ToField d, ToField e, ToField f) => ToRow (a,b,c,d,e,f)
+deriving instance (ToField a, ToField b, ToField c, ToField d, ToField e, ToField f, ToField g) => ToRow (a,b,c,d,e,f,g)
 
 instance (ToField a, ToField b, ToField c, ToField d, ToField e, ToField f,
           ToField g, ToField h)

--- a/changelog
+++ b/changelog
@@ -1,7 +1,10 @@
+0.4.18.1
+	* Add generic implementation of 'FromRow' and 'ToRow'.
+
 0.4.16.0
 	* Add FromField instance for SQLData (thanks @LindaOrtega, @Shimuuar)
 	* Add QuasiQuoter sql (thanks @vrom911)
-	
+
 0.4.15.0
 	* Support GHC 8.4.1 (Add instance Semigroup Query) (thanks @gwils!)
 

--- a/sqlite-simple.cabal
+++ b/sqlite-simple.cabal
@@ -1,5 +1,5 @@
 Name:                sqlite-simple
-Version:             0.4.18.0
+Version:             0.4.18.1
 Synopsis:            Mid-Level SQLite client library
 Description:
     Mid-level SQLite client library, based on postgresql-simple.


### PR DESCRIPTION
This is my first time ever doing data-type generic programming, so
please review this carefully.  I conferred with [the documentation in
base](http://hackage.haskell.org/package/base-4.12.0.0/docs/GHC-Generics.html#g:10) and I also looked at the analoguous definition in the package
[`binary`](http://hackage.haskell.org/package/binary).  It was surprisingly easy to implement, but perhaps it
should be tested some more before merging in.  I've just quickly
tested it with the code-base I'm working on.

Note that the current implementation can only derive the generic
instance for product-types (not sum-types).