### PR TITLE
Update to GHC 8.8.1. Trimmed warnings.

### DIFF
--- a/.ghci
+++ b/.ghci
@@ -1,0 +1,13 @@
+:set -XNamedFieldPuns
+:set -XOverloadedStrings
+:set -XRank2Types
+:set -XRecordWildCards
+:set -XDoAndIfThenElse
+:set -XOverloadedStrings
+:set -XBangPatterns
+:set -XViewPatterns
+:set -XTypeOperators
+:set -Wall
+:set -fno-warn-name-shadowing
+:set -i.
+:set -itest

--- a/Database/SQLite/Simple.hs
+++ b/Database/SQLite/Simple.hs
@@ -102,7 +102,6 @@ module Database.SQLite.Simple (
   , Base.Error(..)
   ) where
 
-import           Control.Applicative
 import           Control.Exception
 import           Control.Monad (void, when, forM_)
 import           Control.Monad.Trans.Reader

--- a/Database/SQLite/Simple/FromField.hs
+++ b/Database/SQLite/Simple/FromField.hs
@@ -34,7 +34,6 @@ module Database.SQLite.Simple.FromField
     , returnError
     ) where
 
-import           Control.Applicative (Applicative, (<$>), pure)
 import           Control.Exception (SomeException(..), Exception)
 import           Data.ByteString (ByteString)
 import qualified Data.ByteString.Char8 as B
@@ -44,7 +43,7 @@ import           Data.Time (UTCTime, Day)
 import qualified Data.Text as T
 import qualified Data.Text.Lazy as LT
 import           Data.Typeable (Typeable, typeOf)
-import           Data.Word (Word, Word8, Word16, Word32, Word64)
+import           Data.Word (Word8, Word16, Word32, Word64)
 import           GHC.Float (double2Float)
 
 import           Database.SQLite3 as Base

--- a/Database/SQLite/Simple/FromRow.hs
+++ b/Database/SQLite/Simple/FromRow.hs
@@ -24,7 +24,6 @@ module Database.SQLite.Simple.FromRow
      , numFieldsRemaining
      ) where
 
-import           Control.Applicative (Applicative(..), (<$>))
 import           Control.Exception (SomeException(..))
 import           Control.Monad (replicateM)
 import           Control.Monad.Trans.State.Strict

--- a/Database/SQLite/Simple/Internal.hs
+++ b/Database/SQLite/Simple/Internal.hs
@@ -19,8 +19,6 @@
 
 module Database.SQLite.Simple.Internal where
 
-import           Prelude hiding (catch)
-
 import           Control.Exception (Exception)
 import           Control.Monad
 import           Control.Applicative

--- a/Database/SQLite/Simple/Ok.hs
+++ b/Database/SQLite/Simple/Ok.hs
@@ -72,6 +72,7 @@ instance Monad Ok where
     Errors es >>= _ = Errors es
     Ok a      >>= f = f a
 
+instance MonadFail Ok where
     fail str = Errors [SomeException (ErrorCall str)]
 
 -- | a way to reify a list of exceptions into a single exception

--- a/Database/SQLite/Simple/Time/Implementation.hs
+++ b/Database/SQLite/Simple/Time/Implementation.hs
@@ -29,7 +29,6 @@ import           Data.Bits ((.&.))
 import           Data.ByteString.Internal (w2c)
 import           Data.Char (isDigit, ord)
 import           Data.Fixed (Pico)
-import           Data.Monoid (Monoid(..))
 import qualified Data.Text as T
 import           Data.Time hiding (getTimeZone, getZonedTime)
 import           Prelude hiding (take, (++))

--- a/Database/SQLite/Simple/ToField.hs
+++ b/Database/SQLite/Simple/ToField.hs
@@ -26,7 +26,7 @@ import qualified Data.Text as T
 import qualified Data.Text.Lazy as LT
 import qualified Data.Text.Encoding as T
 import           Data.Time (Day, UTCTime)
-import           Data.Word (Word, Word8, Word16, Word32, Word64)
+import           Data.Word (Word8, Word16, Word32, Word64)
 import           GHC.Float
 
 import           Database.SQLite3 as Base

--- a/Database/SQLite/Simple/Types.hs
+++ b/Database/SQLite/Simple/Types.hs
@@ -24,8 +24,6 @@ module Database.SQLite.Simple.Types
     ) where
 
 import           Control.Arrow (first)
-import           Data.Monoid (Monoid(..))
-import           Data.Semigroup (Semigroup(..))
 import           Data.String (IsString(..))
 import           Data.Tuple.Only (Only(..))
 import           Data.Typeable (Typeable)

--- a/sqlite-simple.cabal
+++ b/sqlite-simple.cabal
@@ -1,5 +1,5 @@
 Name:                sqlite-simple
-Version:             0.4.16.0
+Version:             0.4.16.1
 Synopsis:            Mid-Level SQLite client library
 Description:
     Mid-level SQLite client library, based on postgresql-simple.

--- a/test/Errors.hs
+++ b/test/Errors.hs
@@ -11,7 +11,6 @@ module Errors (
   , testErrorsExclusiveTransaction
   ) where
 
-import           Prelude hiding (catch)
 import           Control.Exception
 import qualified Data.ByteString as B
 import qualified Data.ByteString.Lazy as LB
@@ -22,7 +21,6 @@ import           Data.Time (Day, UTCTime)
 
 import           Common
 import           Database.SQLite.Simple.Types (Null)
-import           Database.SQLite3 (SQLError)
 
 -- The "length (show e) `seq` .." trickery below is to force evaluate
 -- the contents of error messages.  Another option would be to log

--- a/test/ParamConv.hs
+++ b/test/ParamConv.hs
@@ -1,3 +1,4 @@
+{-# OPTIONS_GHC -Wno-overflowed-literals #-}
 {-# LANGUAGE ScopedTypeVariables, OverloadedStrings #-}
 
 module ParamConv (
@@ -13,7 +14,6 @@ module ParamConv (
   , testParamConvComposite
   , testParamNamed) where
 
-import           Control.Applicative
 import           Data.Int
 import           Data.Word
 import           Data.Time
@@ -133,10 +133,10 @@ testParamConvDateTime TestEnv{..} = TestCase $ do
   -- TODO should _rows be forced to make sure parsers kick on the
   -- returned data?
   execute conn "INSERT INTO dt (t1,t2) VALUES (?,?)"
-    (read "2012-08-12" :: Day, read "2012-08-12 01:01:01" :: UTCTime)
+    (read "2012-08-12" :: Day, read "2012-08-12 01:01:01 UTC" :: UTCTime)
   [_,(t1,t2)] <- query_ conn "SELECT t1,t2 from dt" :: IO [(Day, UTCTime)]
   assertEqual "day" (read "2012-08-12" :: Day) t1
-  assertEqual "day" (read "2012-08-12 01:01:01" :: UTCTime) t2
+  assertEqual "day" (read "2012-08-12 01:01:01 UTC" :: UTCTime) t2
 
 
 testParamConvBools :: TestEnv -> Test

--- a/test/TestImports.hs
+++ b/test/TestImports.hs
@@ -4,7 +4,6 @@ module TestImports (
   ) where
 
 -- Test file to test that we can do most things with a single import
-import           Control.Applicative
 import qualified Data.Text as T
 
 import           Common


### PR DESCRIPTION
I've built with GHC 8.8.1 and trimmed all warnings and errors.

Also added a .ghci file mirroring extensions and options from the cabal file, which makes it easier to use e.g. ghcid.

Worth noting is the format accepted by `instance Read UTCTime` has changed (my version is time-1.9.3), now requiring a "UTC" suffix. So far I have just added this, but it would be bad thing if this change introduced a lower version bound on the time library.