### PR TITLE
Add withSavepoint

### DIFF
--- a/Database/SQLite/Simple/Function.hs
+++ b/Database/SQLite/Simple/Function.hs
@@ -55,8 +55,8 @@ instance {-# Overlapping #-} forall f r . (Function r, FromField f) => Function 
       Errors ex -> throw $ ManyErrors ex
 
 createFunction :: forall f . Function f => Connection -> T.Text -> f -> IO (Either Base.Error ())
-createFunction (Connection db) fn f = Base.createFunction
-  db
+createFunction conn fn f = Base.createFunction
+  (connectionHandle conn)
   (Base.Utf8 $ TE.encodeUtf8 fn)
   (Just $ Base.ArgCount $ argCount (Proxy :: Proxy f))
   (deterministicFn (Proxy :: Proxy f))
@@ -65,7 +65,7 @@ createFunction (Connection db) fn f = Base.createFunction
     ((const :: IO () -> SomeException -> IO ()) $ Base.funcResultNull ctx))
 
 deleteFunction :: Connection -> T.Text -> IO (Either Base.Error ())
-deleteFunction (Connection db) fn = Base.deleteFunction
-  db
+deleteFunction conn fn = Base.deleteFunction
+  (connectionHandle conn)
   (Base.Utf8 $ TE.encodeUtf8 fn)
   Nothing

--- a/Database/SQLite/Simple/Internal.hs
+++ b/Database/SQLite/Simple/Internal.hs
@@ -24,7 +24,9 @@ import           Control.Monad
 import           Control.Applicative
 import           Data.ByteString (ByteString)
 import           Data.ByteString.Char8()
+import           Data.IORef
 import           Data.Typeable (Typeable)
+import           Data.Word
 import           Control.Monad.Trans.State.Strict
 import           Control.Monad.Trans.Reader
 
@@ -39,7 +41,10 @@ import qualified Database.SQLite3 as Base
 -- functionality that's not exposed in the sqlite-simple API.  This
 -- should be a safe thing to do although mixing both APIs is
 -- discouraged.
-newtype Connection = Connection { connectionHandle :: Base.Database }
+data Connection = Connection
+  { connectionHandle :: {-# UNPACK #-} !Base.Database
+  , connectionTempNameCounter :: {-# UNPACK #-} !(IORef Word64)
+  }
 
 data ColumnOutOfBounds = ColumnOutOfBounds { errorColumnIndex :: !Int }
                       deriving (Eq, Show, Typeable)

--- a/test/DirectSqlite.hs
+++ b/test/DirectSqlite.hs
@@ -14,7 +14,7 @@ testDirectSqlite :: TestEnv -> Test
 testDirectSqlite TestEnv{..} = TestCase $ do
   let dsConn = connectionHandle conn
   bracket (DS.prepare dsConn "SELECT 1+1") DS.finalize testDirect
-  [Only (res :: Int)] <- query_ (Connection dsConn) "SELECT 1+2"
+  [Only (res :: Int)] <- query_ conn "SELECT 1+2"
   assertEqual "1+2" 3 res
   where
     testDirect stmt = do

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -52,6 +52,7 @@ tests =
     , TestLabel "Errors"    . testErrorsTransaction
     , TestLabel "Errors"    . testErrorsImmediateTransaction
     , TestLabel "Errors"    . testErrorsExclusiveTransaction
+    , TestLabel "Errors"    . testErrorsSavepoint
     , TestLabel "Utf8"      . testUtf8Simplest
     , TestLabel "Utf8"      . testBlobs
     , TestLabel "Instances" . testUserFromField


### PR DESCRIPTION
This mirrors postgresql-simple's [`withSavepoint`](http://hackage.haskell.org/package/postgresql-simple-0.6.2/docs/Database-PostgreSQL-Simple-Transaction.html#v:withSavepoint).

SQLite's savepoints are actually even more general since they can be used as top-level transactions.