### PR TITLE
Add FromField and ToField instance for Data.UUID

### DIFF
--- a/Database/SQLite/Simple/FromField.hs
+++ b/Database/SQLite/Simple/FromField.hs
@@ -43,6 +43,8 @@ import           Data.Time (UTCTime, Day)
 import qualified Data.Text as T
 import qualified Data.Text.Lazy as LT
 import           Data.Typeable (Typeable, typeOf)
+import           Data.UUID.Types (UUID)
+import qualified Data.UUID.Types as UUID
 import           Data.Word (Word8, Word16, Word32, Word64)
 import           GHC.Float (double2Float)
 
@@ -185,6 +187,13 @@ instance FromField UTCTime where
 
   fromField f = returnError ConversionFailed f "expecting SQLText column type"
 
+instance FromField UUID where
+  fromField f@(Field (SQLText t) _) =
+    case UUID.fromText t of
+      Just uuid -> Ok uuid
+      Nothing -> returnError ConversionFailed f "couldn't parse UUID field"
+
+  fromField f = returnError ConversionFailed f "expecting SQLText column type"
 
 instance FromField Day where
   fromField f@(Field (SQLText t) _) =

--- a/Database/SQLite/Simple/ToField.hs
+++ b/Database/SQLite/Simple/ToField.hs
@@ -26,6 +26,8 @@ import qualified Data.Text as T
 import qualified Data.Text.Lazy as LT
 import qualified Data.Text.Encoding as T
 import           Data.Time (Day, UTCTime)
+import           Data.UUID.Types (UUID)
+import qualified Data.UUID.Types as UUID
 import           Data.Word (Word8, Word16, Word32, Word64)
 import           GHC.Float
 
@@ -130,6 +132,10 @@ instance ToField LT.Text where
 
 instance ToField UTCTime where
     toField = SQLText . T.decodeUtf8 . toByteString . utcTimeToBuilder
+    {-# INLINE toField #-}
+
+instance ToField UUID where
+    toField = SQLText . UUID.toText
     {-# INLINE toField #-}
 
 instance ToField Day where

--- a/sqlite-simple.cabal
+++ b/sqlite-simple.cabal
@@ -56,6 +56,7 @@ Library
     text >= 0.11,
     time,
     transformers,
+    uuid-types >= 1.0.0,
     Only >= 0.1 && < 0.1.1
 
   default-extensions:
@@ -108,3 +109,4 @@ test-suite test
                , direct-sqlite
                , text
                , time
+               , uuid

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -33,6 +33,7 @@ tests =
     , TestLabel "Simple"    . testSimpleQueryCov
     , TestLabel "Simple"    . testSimpleStrings
     , TestLabel "Simple"    . testSimpleChanges
+    , TestLabel "Simple"    . testSimpleUUID
     , TestLabel "ParamConv" . testParamConvNull
     , TestLabel "ParamConv" . testParamConvInt
     , TestLabel "ParamConv" . testParamConvIntWidths


### PR DESCRIPTION
The implementation is based on `postgresql-simple`([FromField](https://hackage.haskell.org/package/postgresql-simple-0.5.3.0/docs/Database-PostgreSQL-Simple-FromField.html#t:FromField), [ToField](https://hackage.haskell.org/package/postgresql-simple-0.6.2/docs/Database-PostgreSQL-Simple-ToField.html#t:ToField)). [`uuid-types`](https://hackage.haskell.org/package/uuid-types-1.0.3) is used because it contains fewer transitive dependencies, but [`uuid`](https://hackage.haskell.org/package/uuid) is used as a dependency for the test case.

This fixes #62.