### PR TITLE
Add MonadThrow instance for Ok

### DIFF
--- a/Database/SQLite/Simple/Ok.hs
+++ b/Database/SQLite/Simple/Ok.hs
@@ -33,6 +33,7 @@ module Database.SQLite.Simple.Ok where
 import Control.Applicative
 import Control.Exception
 import Control.Monad (MonadPlus(..))
+import Control.Monad.Catch (MonadThrow, throwM)
 import Data.Typeable
 
 #if !MIN_VERSION_base(4,13,0) && MIN_VERSION_base(4,9,0)
@@ -80,6 +81,9 @@ instance Monad Ok where
 #if MIN_VERSION_base(4,9,0)
 instance MonadFail Ok where
     fail str = Errors [SomeException (ErrorCall str)]
+
+instance MonadThrow Ok where
+    throwM = fail . show
 #endif
 
 -- | a way to reify a list of exceptions into a single exception

--- a/sqlite-simple.cabal
+++ b/sqlite-simple.cabal
@@ -51,6 +51,7 @@ Library
     bytestring >= 0.9,
     containers,
     direct-sqlite >= 2.3.13 && < 2.4,
+    exceptions >= 0.4,
     semigroups >= 0.18 && < 0.20,
     template-haskell,
     text >= 0.11,


### PR DESCRIPTION
This enables the use of functions for `FromField` instances with a `MonadThrow` constraint without having to use orphaned instances of `Ok`.

E.g. using `mkURI` from [Text.URI](https://hackage.haskell.org/package/modern-uri-0.3.2.0/docs/Text-URI.html#v:mkURI) for storing type-safe URLs requires this.