### PR TITLE
Depend on semigroups only on GHC < 8.0

### DIFF
--- a/sqlite-simple.cabal
+++ b/sqlite-simple.cabal
@@ -51,12 +51,14 @@ Library
     bytestring >= 0.9,
     containers,
     direct-sqlite >= 2.3.13 && < 2.4,
-    semigroups >= 0.18 && < 0.20,
     template-haskell,
     text >= 0.11,
     time,
     transformers,
     Only >= 0.1 && < 0.1.1
+    
+  if impl(ghc < 8.0)
+    Build-depends: semigroups >= 0.18 && < 0.20
 
   default-extensions:
       DoAndIfThenElse


### PR DESCRIPTION
They are not needed on newer GHC.