### PR TITLE
Fix MonadThrow instance

### DIFF
--- a/Database/SQLite/Simple/Ok.hs
+++ b/Database/SQLite/Simple/Ok.hs
@@ -81,10 +81,11 @@ instance Monad Ok where
 #if MIN_VERSION_base(4,9,0)
 instance MonadFail Ok where
     fail str = Errors [SomeException (ErrorCall str)]
+#endif
 
 instance MonadThrow Ok where
-    throwM = fail . show
-#endif
+    throwM = Errors . pure . toException
+
 
 -- | a way to reify a list of exceptions into a single exception
 


### PR DESCRIPTION
Since Ok can store any exception in makes no reason to erase type of exception
and convert it to ErrorCall

This also makes MonadThrow instance not conditional on existence of MonadFail
instances