### PR TITLE
Remove noncanonical definitions

### DIFF
--- a/Database/SQLite/Simple/Ok.hs
+++ b/Database/SQLite/Simple/Ok.hs
@@ -73,8 +73,6 @@ instance MonadPlus Ok where
     mplus = (<|>)
 
 instance Monad Ok where
-    return = Ok
-
     Errors es >>= _ = Errors es
     Ok a      >>= f = f a
 


### PR DESCRIPTION
This appeases the -Wnoncanonical-monad-instances warning. This warning exists because a future GHC release may treat noncanonical definitions as errors.

See also:
  https://gitlab.haskell.org/ghc/ghc/-/wikis/proposal/monad-of-no-return